### PR TITLE
remove transaction seeder from overall seeders

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,7 +21,6 @@ class DatabaseSeeder extends Seeder
             RolesSeeder::class,
             RoleUserSeeder::class,
             ChoresSeeder::class,
-            transactionSeeder::class,
             rewards_table_seeder::class,
             UserChoreSeeder::class
         ]);


### PR DESCRIPTION
This PR removes the transactions seeder from the overall seeders. We don't want the admin user to start out with points.