### PR TITLE
fix styling issues on chore assignment page

### DIFF
--- a/resources/js/components/ListItem.vue
+++ b/resources/js/components/ListItem.vue
@@ -1,9 +1,8 @@
 <template>
     <li :id="listItem.id" class="list-group-item justify-between items-center" v-bind:data-itemId="listItem.id" v-on:click="handleChoreClick" v-on:dragstart="dragStart" draggable="draggable">
         <slot></slot>
-        <div>
-            <slot name="actions"></slot>
-        </div>
+
+        <slot name="actions"></slot>
     </li>
 </template>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,7 +22,7 @@ module.exports = {
         // grid spacing for expanded menu
         'menucollapsed': '48px 1fr',
 
-        'listitemgrid': '1fr 2.5rem',
+        'listitemgrid': '1fr 2.5rem 2.5rem',
       }
     },
   },


### PR DESCRIPTION
This PR fixes the styling on the manage chores page chore list items so that the action buttons dont stack