### PR TITLE
remove the screensize watcher, which is no longer needed

### DIFF
--- a/resources/js/components/AppMenu.vue
+++ b/resources/js/components/AppMenu.vue
@@ -58,11 +58,8 @@ export default {
 
         });
 
-        if (this.windowWidth < 640) {
-            this.mainMenuIsOpen = false;
-        } else {
-            this.mainMenuIsOpen = false;
-        }
+        this.mainMenuIsOpen = false;
+        
     },
 
     data() {
@@ -77,16 +74,6 @@ export default {
     computed: {
         windowWidth() {
             return this.$store.getters.getWindowWidth;
-        }
-    },
-
-    watch: {
-        windowWidth(newWidth, oldWidth) {
-            if (newWidth > 640) {
-                this.mainMenuIsOpen = true;
-            } else {
-                this.mainMenuIsOpen = false;
-            }
         }
     },
 
@@ -107,7 +94,6 @@ export default {
         },
 
         clickMobileMainMenu() {
-            // this.mainMenuIsOpen = !this.mainMenuIsOpen;
             eventBus.emit('mobileMainMenuIconClicked', this);
         }
     },

--- a/resources/js/pages/ChoresList.vue
+++ b/resources/js/pages/ChoresList.vue
@@ -69,9 +69,7 @@ export default {
 
     created() {
         eventBus.on("mobileMainMenuIconClicked", () => {
-
             this.mainMenuIsOpen = !this.mainMenuIsOpen;
-
         });
 
         this.mainMenuIsOpen = false;


### PR DESCRIPTION
This PR removes the screen size watcher. It's no longer needed since the menu now has the same behavior across mobile and desktop